### PR TITLE
Automated CI with Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,6 @@
-start of travis ci
+language: node_js
+node_js:
+  - "4.1"
+install:
+  - make test
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: node_js
 node_js:
   - "4.1"
 sudo: required
+services:
+  - docker
 install:
   - make test
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
   - "4.1"
+sudo: required
 install:
   - make test
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+start of travis ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,6 @@ sudo: required
 services:
   - docker
 install:
+  - make developer
   - make test
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,7 @@ services:
 install:
   - make developer
   - make test
+# Post to Slack
+notifications:
+  slack: jencateam:m1Z9iUkUDDtl77hoUlm4SQEb
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,16 @@ To run the tests in the Vagrant development environment, run:
 vagrant$ make tests
 ```
 
+### Contributing
+
+Jenca cloud uses [Travis-CI](https://travis-ci.org/jenca-cloud/jenca-cloud/) to run tests on each push of each branch.
+We use [Trello](https://trello.com/b/clWQd0u9/jenca-cloud-development) to track progress on work.
+To contribute to Jenca, create or find a Trello card, and create a branch with a name consisting of `issue-summary-<TRELLO-CARD-ID>`.
+You can find the ID of a card by going to the card, choosing "Share and more..." and then selecting the final part of the link to the card.
+
+When making changes
+Make changes for a card 
+
 ## Production
 
 Spin up new server. See install.sh

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ We use [Trello](https://trello.com/b/clWQd0u9/jenca-cloud-development) to track 
 To contribute to Jenca, create or find a Trello card, and create a branch with a name consisting of `issue-summary-<TRELLO-CARD-ID>`.
 You can find the ID of a card by going to the card, choosing "Share and more..." and then selecting the final part of the link to the card.
 
-When making changes
-Make changes for a card 
+Make changes on the branch and create a Pull Request in GitHub against `master`.
+Only merge the branch into `master` once Travis reports that all tests have passed.
 
 ## Production
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/jenca-cloud/jenca-cloud.svg?branch=master)](https://travis-ci.org/jenca-cloud/jenca-cloud)
+
 ## jenca cloud
 
 An easy way to run BIM applications in the cloud.


### PR DESCRIPTION
This adds automated builds with Travis CI (free), and notifications to a new Slack channel from Travis.

This also adds a basic "Contributing" docs section, explaining how to get Travis to build branches.

Fixes: https://trello.com/c/U8eANtvh/28-add-automated-ci
Follow up issue for `node` version(s): https://trello.com/c/eiyIZQvV/33-specify-node-version-requirements-for-travis-ci

Note that this can be seen in action on this Pull Request. Look at the list of :x: s and :white_check_mark: s next to the commit IDs.