### PR TITLE
fix jenactl script

### DIFF
--- a/scripts/jencactl
+++ b/scripts/jencactl
@@ -96,6 +96,7 @@ cmd-updatecode-repo() {
 
 	if [[ ! -d "/vagrant/repos/${repo}" ]]; then
 		echo "cloning $repo"
+		mkdir -p /vagrant/repos
 		cd /vagrant/repos && git clone https://github.com/jenca-cloud/${repo}.git
 	fi
 


### PR DESCRIPTION
I fixed a minor bug in the jenactl script. You need to create the dir `/vagrant/repos` if it is absent otherwise the provisioning will fail:

```Bash
==> default: /usr/local/bin/jencactl: line 99: cd: /vagrant/repos: No such file or directory
==> default: /usr/local/bin/jencactl: line 102: cd: /vagrant/repos/jenca-authorization: No such file or directory
The SSH command responded with a non-zero exit status. Vagrant
assumes that this means the command failed. The output for this command
should be in the log above. Please read the output to determine what
went wrong.
```